### PR TITLE
Feature/colorize globalmap

### DIFF
--- a/apps/globalmap_server_nodelet.cpp
+++ b/apps/globalmap_server_nodelet.cpp
@@ -14,11 +14,23 @@
 
 #include <pcl/filters/voxel_grid.h>
 
+struct EIGEN_ALIGN16 PointXYZRGBI
+{
+  PCL_ADD_POINT4D
+  PCL_ADD_RGB;
+  PCL_ADD_INTENSITY;
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
+POINT_CLOUD_REGISTER_POINT_STRUCT(PointXYZRGBI, 
+                                  (float, x, x)(float, y, y)(float, z, z)
+                                  (float, rgb, rgb)
+                                  (float, intensity, intensity))
+
 namespace hdl_localization {
 
 class GlobalmapServerNodelet : public nodelet::Nodelet {
 public:
-  using PointT = pcl::PointXYZI;
+  using PointT = PointXYZRGBI;
 
   GlobalmapServerNodelet() {
   }

--- a/apps/globalmap_server_nodelet.cpp
+++ b/apps/globalmap_server_nodelet.cpp
@@ -1,3 +1,5 @@
+#define PCL_NO_PRECOMPILE
+
 #include <mutex>
 #include <memory>
 #include <iostream>


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary
Navigation時のGlobalmapに色情報が付与されます。
<!-- このPull Requestで解決されるIssue
fix #22 
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- fix #22 

<img src="https://user-images.githubusercontent.com/84959376/221461724-e8097653-9bb2-4d61-878a-bf4341ce3b50.png" width="350px">　<img src="https://user-images.githubusercontent.com/84959376/221461792-2ad13426-fd42-4833-a2aa-d3e49bf20786.png" width="350px">

<!-- 変更の詳細 -->
## Detail
カスタム型PointTの導入により、以下の通りRGBフィールドを追加しました。
https://github.com/sbgisen/hdl_localization/blob/5178c34175c66e7a92e1d987232ab2e6922d3e26/apps/globalmap_server_nodelet.cpp#L19-L29
https://github.com/sbgisen/hdl_localization/blob/5178c34175c66e7a92e1d987232ab2e6922d3e26/apps/globalmap_server_nodelet.cpp#L35
<!-- この関数を変更したのでこの機能にも影響がある、など -->
<!-- ## Impact -->

<!-- どのような動作検証を行ったか -->
## Test
<!-- ROS package向け Template -->
  <!-- * [ ] gazebo環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] 実機環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] (アプリ名)で動作検証した -->
* [x] 実機で動作確認

<!-- ## Attention -->
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
