### PR TITLE
Disable down sampling if downsample_resolution is zero

### DIFF
--- a/src/nodelet/hdl_localization_nodelet.cpp
+++ b/src/nodelet/hdl_localization_nodelet.cpp
@@ -151,10 +151,18 @@ void HdlLocalizationNodelet::initializeParams()
 {
   // intialize scan matching method
   double downsample_resolution = private_nh_.param<double>("downsample_resolution", 0.1);
-  boost::shared_ptr<pcl::VoxelGrid<HdlLocalizationNodelet::PointT>> voxelgrid(
-      new pcl::VoxelGrid<HdlLocalizationNodelet::PointT>());
-  voxelgrid->setLeafSize(downsample_resolution, downsample_resolution, downsample_resolution);
-  downsample_filter_ = voxelgrid;
+  if (downsample_resolution > std::numeric_limits<double>::epsilon())
+  {
+    boost::shared_ptr<pcl::VoxelGrid<HdlLocalizationNodelet::PointT>> voxelgrid(
+        new pcl::VoxelGrid<HdlLocalizationNodelet::PointT>());
+    voxelgrid->setLeafSize(downsample_resolution, downsample_resolution, downsample_resolution);
+    downsample_filter_ = voxelgrid;
+  }
+  else
+  {
+    ROS_WARN("Input downsample_filter_ is disabled");
+    downsample_filter_.reset();
+  }
 
   NODELET_INFO("create registration method for localization");
   registration_ = createRegistration();


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary
downsample_resolutionが0のときダウンサンプルを無効にし、エラー落ちしないようにしました

<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- fix #31 

<!-- 変更の詳細 -->
## Detail

<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

<!-- どのような動作検証を行ったか -->
## Test
<!-- ROS package向け Template -->
  <!-- * [ ] gazebo環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] 実機環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] (アプリ名)で動作検証した -->

## Attention
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
