### PR TITLE
Feature/rename params

### DIFF
--- a/include/hdl_localization/pose_estimator.hpp
+++ b/include/hdl_localization/pose_estimator.hpp
@@ -42,8 +42,8 @@ public:
    * @param quat                initial orientation
    * @param cool_time_duration  during "cool time", prediction is not performed
    */
-  PoseEstimator(pcl::Registration<PointT, PointT>::Ptr& registration, const Eigen::Vector3f& pos,
-                const Eigen::Quaternionf& quat, double cool_time_duration = 1.0);
+  PoseEstimator(pcl::Registration<PointT, PointT>::Ptr& registration, const Eigen::Vector3f& initial_position,
+                const Eigen::Quaternionf& initial_orientation, double cool_time_duration = 1.0);
   ~PoseEstimator();
 
   /**
@@ -86,8 +86,7 @@ public:
   Eigen::Matrix4f matrix() const;
 
   const boost::optional<Eigen::Matrix4f>& woPredictionError() const;
-  const boost::optional<Eigen::Matrix4f>& imuPredictionError() const;
-  const boost::optional<Eigen::Matrix4f>& odomPredictionError() const;
+  const boost::optional<Eigen::Matrix4f>& motionPredictionError() const;
 
 private:
   ros::Time init_stamp_;             // when the estimator was initialized
@@ -100,8 +99,7 @@ private:
 
   Eigen::Matrix4f last_observation_;
   boost::optional<Eigen::Matrix4f> wo_pred_error_;
-  boost::optional<Eigen::Matrix4f> imu_pred_error_;
-  boost::optional<Eigen::Matrix4f> odom_pred_error_;
+  boost::optional<Eigen::Matrix4f> motion_pred_error_;
 
   pcl::Registration<PointT, PointT>::Ptr registration_;
 };

--- a/include/nodelet/globalmap_server_nodelet.hpp
+++ b/include/nodelet/globalmap_server_nodelet.hpp
@@ -49,6 +49,7 @@ private:
   ros::NodeHandle mt_nh_;
   ros::NodeHandle private_nh_;
 
+  std::string global_frame_id_;
   ros::Publisher globalmap_pub_;
   ros::Subscriber map_update_sub_;
 

--- a/include/nodelet/hdl_localization_nodelet.hpp
+++ b/include/nodelet/hdl_localization_nodelet.hpp
@@ -65,11 +65,12 @@ private:
   ros::NodeHandle mt_nh_;
   ros::NodeHandle private_nh_;
 
+  std::string global_frame_id_;
+  std::string odom_frame_id_;
+  std::string base_frame_id_;
+  bool tf_broadcast_;
   bool use_odom_;
   ros::Time odom_stamp_last_;
-  std::string robot_odom_frame_id_;
-  std::string odom_child_frame_id_;
-  bool enable_tf_;
 
   bool use_imu_;
   bool invert_acc_;

--- a/include/nodelet/hdl_localization_nodelet.hpp
+++ b/include/nodelet/hdl_localization_nodelet.hpp
@@ -69,6 +69,7 @@ private:
   std::string odom_frame_id_;
   std::string base_frame_id_;
   bool tf_broadcast_;
+  double cool_time_duration_;
   bool use_odom_;
   ros::Time odom_stamp_last_;
 

--- a/launch/hdl_localization.launch
+++ b/launch/hdl_localization.launch
@@ -6,15 +6,16 @@
   <!-- input clouds are transformed in odom_child_frame, and then localization is performed in that
   frame -->
   <!-- this is useful to match the LIDAR and IMU coodinate systems -->
-  <arg name="odom_child_frame_id" default="velodyne"/>
+  <arg name="base_frame_id" default="velodyne"/>
+  <arg name="global_frame_id" value="map"/>
   <!-- optional arguments -->
   <arg name="use_imu" default="false"/>
+  <arg name="use_odom" value="false"/>
   <arg name="invert_imu_acc" default="false"/>
   <arg name="invert_imu_gyro" default="false"/>
   <arg name="use_global_localization" default="true"/>
   <arg name="imu_topic" default="/imu/data"/>
-  <arg name="enable_robot_odometry_prediction" value="false"/>
-  <arg name="robot_odom_frame_id" value="odom"/>
+  <arg name="odom_frame_id" value="odom"/>
   <arg name="plot_estimation_errors" value="false"/>
   <include file="$(find hdl_global_localization)/launch/hdl_global_localization.launch"
     if="$(arg use_global_localization)"/>
@@ -24,6 +25,7 @@
   <node pkg="nodelet" type="nodelet" name="globalmap_server_nodelet"
     args="load hdl_localization/GlobalmapServerNodelet $(arg nodelet_manager)">
     <param name="globalmap_pcd" value="$(find hdl_localization)/data/map.pcd"/>
+    <param name="global_frame_id" value="$(arg global_frame_id)"/>
     <param name="convert_utm_to_local" value="true"/>
     <param name="downsample_resolution" value="0.1"/>
   </node>
@@ -33,7 +35,8 @@
     <remap from="/velodyne_points" to="$(arg points_topic)"/>
     <remap from="/gpsimu_driver/imu_data" to="$(arg imu_topic)"/>
     <!-- odometry frame_id -->
-    <param name="odom_child_frame_id" value="$(arg odom_child_frame_id)"/>
+    <param name="base_frame_id" value="$(arg base_frame_id)"/>
+    <param name="global_frame_id" value="$(arg global_frame_id)"/>
     <!-- imu settings -->
     <!-- during "cool_time", imu inputs are ignored -->
     <param name="use_imu" value="$(arg use_imu)"/>
@@ -41,8 +44,8 @@
     <param name="invert_gyro" value="$(arg invert_imu_gyro)"/>
     <param name="cool_time_duration" value="2.0"/>
     <!-- robot odometry-based prediction -->
-    <param name="enable_robot_odometry_prediction" value="$(arg enable_robot_odometry_prediction)"/>
-    <param name="robot_odom_frame_id" value="$(arg robot_odom_frame_id)"/>
+    <param name="use_odom" value="$(arg use_odom)"/>
+    <param name="odom_frame_id" value="$(arg odom_frame_id)"/>
     <!-- ndt settings -->
     <!-- available reg_methods: NDT_OMP, NDT_CUDA_P2D, NDT_CUDA_D2D-->
     <param name="reg_method" value="NDT_OMP"/>
@@ -63,12 +66,12 @@
     <param name="init_ori_x" value="0.0"/>
     <param name="init_ori_y" value="0.0"/>
     <param name="init_ori_z" value="0.0"/>
-    <param name="cov_scaling_factor_x" value="1.0"/>
-    <param name="cov_scaling_factor_y" value="1.0"/>
-    <param name="cov_scaling_factor_z" value="1.0"/>
-    <param name="cov_scaling_factor_R" value="1.0"/>
-    <param name="cov_scaling_factor_P" value="1.0"/>
-    <param name="cov_scaling_factor_Y" value="1.0"/>
+    <param name="cov_scale_x" value="1.0"/>
+    <param name="cov_scale_y" value="1.0"/>
+    <param name="cov_scale_z" value="1.0"/>
+    <param name="cov_scale_roll" value="1.0"/>
+    <param name="cov_scale_pitch" value="1.0"/>
+    <param name="cov_scale_yaw" value="1.0"/>
     <param name="use_global_localization" value="$(arg use_global_localization)"/>
   </node>
   <node pkg="hdl_localization" type="plot_status.py" name="plot_estimation_errors"

--- a/src/nodelet/globalmap_server_nodelet.cpp
+++ b/src/nodelet/globalmap_server_nodelet.cpp
@@ -30,9 +30,10 @@ void GlobalmapServerNodelet::initializeParams()
 {
   // read globalmap from a pcd file
   std::string globalmap_pcd = private_nh_.param<std::string>("globalmap_pcd", "");
+  global_frame_id_ = private_nh_.param<std::string>("global_frame_id", "map");
   globalmap_.reset(new pcl::PointCloud<PointT>());
   pcl::io::loadPCDFile(globalmap_pcd, *globalmap_);
-  globalmap_->header.frame_id = "map";
+  globalmap_->header.frame_id = global_frame_id_;
 
   std::ifstream utm_file(globalmap_pcd + ".utm");
   if (utm_file.is_open() && private_nh_.param<bool>("convert_utm_to_local", true))
@@ -76,7 +77,7 @@ void GlobalmapServerNodelet::mapUpdateCallback(const std_msgs::String& msg)
   std::string globalmap_pcd = msg.data;
   globalmap_.reset(new pcl::PointCloud<PointT>());
   pcl::io::loadPCDFile(globalmap_pcd, *globalmap_);
-  globalmap_->header.frame_id = "map";
+  globalmap_->header.frame_id = global_frame_id_;
   // downsample globalmap
   double downsample_resolution = private_nh_.param<double>("downsample_resolution", 0.1);
   if (downsample_resolution > std::numeric_limits<double>::epsilon())

--- a/src/nodelet/hdl_localization_nodelet.cpp
+++ b/src/nodelet/hdl_localization_nodelet.cpp
@@ -34,13 +34,13 @@ void HdlLocalizationNodelet::onInit()
   invert_acc_ = private_nh_.param<bool>("invert_acc", false);
   invert_gyro_ = private_nh_.param<bool>("invert_gyro", false);
   bool specify_init_pose = private_nh_.param<bool>("specify_init_pose", false);
-  Eigen::Vector3f init_pose = Eigen::Vector3f::Zero();
+  Eigen::Vector3f init_position = Eigen::Vector3f::Zero();
   Eigen::Quaternionf init_orientation = Eigen::Quaternionf::Identity();
   if (specify_init_pose)
   {
-    init_pose.x() = private_nh_.param<double>("init_pos_x", 0.0);
-    init_pose.y() = private_nh_.param<double>("init_pos_y", 0.0);
-    init_pose.z() = private_nh_.param<double>("init_pos_z", 0.0);
+    init_position.x() = private_nh_.param<double>("init_pos_x", 0.0);
+    init_position.y() = private_nh_.param<double>("init_pos_y", 0.0);
+    init_position.z() = private_nh_.param<double>("init_pos_z", 0.0);
     init_orientation.x() = private_nh_.param<double>("init_ori_x", 0.0);
     init_orientation.y() = private_nh_.param<double>("init_ori_y", 0.0);
     init_orientation.z() = private_nh_.param<double>("init_ori_z", 0.0);
@@ -49,7 +49,7 @@ void HdlLocalizationNodelet::onInit()
   // Initialize pose estimator
   NODELET_INFO("initialize pose estimator with specified parameters!!");
   pose_estimator_.reset(
-      new hdl_localization::PoseEstimator(registration_, init_pose, init_orientation, cool_time_duration_));
+      new hdl_localization::PoseEstimator(registration_, init_position, init_orientation, cool_time_duration_));
 
   // Initialize subscriber and publisher
   if (use_imu_)


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary
- パラメータ名・変数名変更
- エラーメッセージの表示頻度変更
- initialposeを受け取った際にセンサのバッファをクリア（imu, odom）
- odomPredictionError()とimuPredictionError()が同じ機能だったのでmotionPredictionError()に統合

<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- fix #27

<!-- 変更の詳細 -->
## Detail

<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

<!-- どのような動作検証を行ったか -->
## Test
<!-- ROS package向け Template -->
  <!-- * [ ] gazebo環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] 実機環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] (アプリ名)で動作検証した -->

## Attention
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
- outdoor_navigation_tools, wheeltec_navigationにも変更を反映する必要があります（Draft PR作成します）
- https://github.com/sbgisen/outdoor_navigation_tools/pull/49
- https://github.com/sbgisen/wheeltec_robot/tree/feature/rename_hdl_params
